### PR TITLE
Add concrete development envrionment URL for 'config.action_mailer.de…

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,5 +51,9 @@ Rails.application.configure do
     :authentication => :plain,
   }
   #config.action_mailer.default_url_options = { :host => '$IP:$PORT' }
-  config.action_mailer.default_url_options = { :host => '$IP', :port => '$PORT' }
+  #config.action_mailer.default_url_options = { :host => '$IP', :port => '$PORT' }
+  
+  # The Cloud 9 development envrioment URL for this Rails app
+  config.action_mailer.default_url_options = { :host => 'https://blocipedia-aspsa.c9users.io/' }
+
 end


### PR DESCRIPTION
…fault_url_options' in 'development.rb' ActionMailer settings.

Dalibor,

Per your recommendation, I substituted the Cloud 9 host:port environment variables with the actual (concrete) Cloud 9 development-level URL for this Rails app.

Lines 56-57 in 'development.rb':
  # The Cloud 9 development envrioment URL for this Rails app
  config.action_mailer.default_url_options = { :host => 'https://blocipedia-aspsa.c9users.io/' }

The corresponding Rails Server log statement...
  <p><a href="https://blocipedia-aspsa.c9users.io//users/confirmation?confirmation_token=tEQLfZ-qtX6sNcRQBVUJ">Confirm my account</a></p>

Unfortunately, I never received the confirmation email. I checked my spam folder, and I waited a reasonable amount of time for the email to arrive.

Flash messaging is implemented...

Regards,

Anthony
